### PR TITLE
Move spieceasi to Imports

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -4,23 +4,23 @@ Title: Network Construction and Comparison for Microbiome Data
 Version: 1.2.0
 Date: 2025-03-14
 Authors@R: c(
-    person("Stefanie", "Peschel", email = "stefpeschel@gmail.com", 
+    person("Stefanie", "Peschel", email = "stefpeschel@gmail.com",
     role = c("aut", "cre"), comment = c(ORCID = "0000-0002-7936-7627")),
     person("Christian L.", "Müller", role = "ctb", comment = c(ORCID = "0000-0002-3821-7083")),
     person("Anne-Laure", "Boulesteix", role = "ctb", comment = c(ORCID = "0000-0002-2729-0947")),
     person("Erika", "von Mutius", role = "ctb", comment = c(ORCID = "0000-0002-8893-4515")),
     person("Martin", "Depner", role = "ctb")
   )
-Description: NetCoMi offers functions for constructing, analyzing, and comparing 
-    microbial association networks as well as dissimilarity-based networks for 
-    microbial compositional data. It also includes functionality for 
+Description: NetCoMi offers functions for constructing, analyzing, and comparing
+    microbial association networks as well as dissimilarity-based networks for
+    microbial compositional data. It also includes functionality for
     constructing differential association networks.
 License: GPL-3 + file LICENSE
 URL: https://netcomi.de, https://github.com/stefpeschel/NetCoMi
 BugReports: https://github.com/stefpeschel/NetCoMi/issues
 Depends: SpiecEasi (>= 1.1.1)
 biocViews:
-Imports: 
+Imports:
     Biobase,
     corrplot,
     doSNOW,
@@ -44,14 +44,14 @@ Imports:
     RColorBrewer,
     Rdpack,
     rlang,
+    SpiecEasi,
     SPRING,
     stats,
     SummarizedExperiment,
     utils,
     vegan,
     WGCNA
-Remotes: 
-    github::zdk123/SpiecEasi,
+Remotes:
     github::GraceYoon/SPRING,
     github::vmikk/metagMisc,
     github::tpq/propr,

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,3 @@
-
 # NetCoMi <img src="man/figures/logo.png" align="right" height="200" />
 
 [![Lifecycle:
@@ -50,18 +49,17 @@ Please visit [netcomi.de](https://netcomi.de/) for a complete reference.
 
 ## Installation
 
-``` r
+```r
 # Required packages
 install.packages("devtools")
 install.packages("BiocManager")
 
-# Since two of NetCoMi's dependencies are only available on GitHub, 
-# it is recommended to install them first:
-devtools::install_github("zdk123/SpiecEasi")
+# Since this NetCoMi's dependency is only available on GitHub,
+# it is recommended to install it first:
 devtools::install_github("GraceYoon/SPRING")
 
 # Install NetCoMi
-devtools::install_github("stefpeschel/NetCoMi", 
+devtools::install_github("stefpeschel/NetCoMi",
                          repos = c("https://cloud.r-project.org/",
                                    BiocManager::repositories()))
 ```
@@ -73,7 +71,7 @@ Packages that are optionally required in certain settings are not
 installed together with NetCoMi. These can be installed automatically
 using:
 
-``` r
+```r
 installNetCoMiPacks()
 ```
 
@@ -85,7 +83,7 @@ installed by the respective NetCoMi function when needed.
 Thanks to [daydream-boost](https://github.com/daydream-boost), NetCoMi
 can also be installed from conda bioconda channel with
 
-``` bash
+```bash
 # You can install an individual environment firstly with
 # conda create -n NetCoMi
 # conda activate NetCoMi
@@ -97,8 +95,8 @@ conda install -c bioconda -c conda-forge r-netcomi
 Everyone who wants to use new features not included in any releases is
 invited to install NetCoMi’s development version:
 
-``` r
-devtools::install_github("stefpeschel/NetCoMi", 
+```r
+devtools::install_github("stefpeschel/NetCoMi",
                          ref = "develop",
                          repos = c("https://cloud.r-project.org/",
                                    BiocManager::repositories()))
@@ -118,7 +116,7 @@ entry-spacing="0">
 Peschel, Stefanie, Christian L Müller, Erika von Mutius, Anne-Laure
 Boulesteix, and Martin Depner. 2020. “<span class="nocase">NetCoMi:
 network construction and comparison for microbiome data in R</span>.”
-*Briefings in Bioinformatics* 22 (4): bbaa290.
+_Briefings in Bioinformatics_ 22 (4): bbaa290.
 <https://doi.org/10.1093/bib/bbaa290>.
 
 </div>


### PR DESCRIPTION
SpiecEasi is now [published](https://bioconductor.org/packages//release/bioc/html/SpiecEasi.html) on Bioconductor, so we do not need to install it from Github.

I tested the build of this package with the following Dockerfile:

```Dockerfile
FROM ghcr.io/bioconductor/bioconductor_docker:RELEASE_3_23-R-4.6.0

# Install system packages
RUN apt-get update && \
    apt-get -y install libcurl4-openssl-dev --no-install-recommends

# Initialize application project directory
WORKDIR /project

# Copy application files into image
COPY . .

RUN R -s -e "install.packages('remotes')"
RUN R -s -e "remotes::install_deps(upgrade = 'always')"
```